### PR TITLE
Created functioning /representatives route

### DIFF
--- a/__tests__/api.spec.ts
+++ b/__tests__/api.spec.ts
@@ -1,6 +1,12 @@
 import { app } from "../src/routes/";
 import frisby from "frisby";
 
+jest.mock("../src/services/representatives", () => {
+  return {
+    getRepresentatives: jest.fn(() => []),
+  };
+});
+
 describe("endpoint smoke tests", () => {
   const HOST = "http://localhost";
   const PORT = 3000;
@@ -17,7 +23,7 @@ describe("endpoint smoke tests", () => {
 
   it("/representatives should exist", async function () {
     const endpoint = `${HOST}:${PORT}/representatives/`;
-    const res = await frisby.get(endpoint);
+    const res = await frisby.post(endpoint);
     expect(res.status).toBe(200);
     expect(res.status).not.toBe(203);
   });

--- a/__tests__/services.spec.ts
+++ b/__tests__/services.spec.ts
@@ -1,0 +1,75 @@
+import { getRepresentatives } from "../src/services/representatives";
+
+// mock out API calls for unit testing
+jest.mock("../src/utils/apiCalls", () => {
+  return {
+    getChamberMembers: jest.fn(() => ["all members"]),
+    getMembersByDistrict: jest.fn((state, district) => [
+      {
+        first_name: "Dan",
+        last_name: "Sullivan",
+        profile_image: "",
+        chamber: "senate",
+        member_id: "S001198",
+        state: "AK",
+      },
+      {
+        first_name: "Lisa",
+        last_name: "Murkowski",
+        profile_image: "",
+        chamber: "senate",
+        member_id: "M001153",
+        state: "AK",
+      },
+      district
+        ? {
+            first_name: "Don",
+            last_name: "Young",
+            profile_image: "",
+            chamber: "house",
+            member_id: "Y000033",
+            state: "AK",
+          }
+        : null,
+    ]),
+  };
+});
+
+jest.mock("../src/utils/apiHelpers", () => {
+  return {
+    responseToMember: jest.fn((input) => input),
+  };
+});
+
+describe("getRepresentatives test suite", () => {
+  test("Should return all members when no body provided", async () => {
+    const mockBody = {};
+    const res = await getRepresentatives(mockBody);
+
+    expect(res).toBeInstanceOf(Array);
+    expect(res[0]).toBe("all members");
+  });
+
+  test("Should return all members in a state if provided", async () => {
+    const mockBody = { state: "FL" };
+    const res = await getRepresentatives(mockBody);
+
+    expect(res).toBeInstanceOf(Array);
+    expect(res.length).toBe(3);
+    expect(res[2]).toBeFalsy();
+    expect(res[1]).toBeTruthy();
+    expect(res[0].first_name).toBe("Dan");
+    expect(res[0].first_name).not.toBe("Jeff");
+  });
+
+  test("Should return 3 relevant members if state and district are provided", async () => {
+    const state = "CO";
+    const district = 1;
+    const mockBody = { state, district };
+    const res = await getRepresentatives(mockBody);
+
+    expect(res).toBeInstanceOf(Array);
+    expect(res.length).toBe(3);
+    expect(res.length).not.toBe(2);
+  });
+});

--- a/babel.config.json
+++ b/babel.config.json
@@ -1,3 +1,3 @@
 {
-  "presets": ["@babel/preset-env"]
+  "presets": ["@babel/preset-env", "@babel/preset-typescript"]
 }

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "Enable users to quickly and intuitively find information regarding their local representatives, upcoming elections, voting patterns and other civic information",
   "main": "server.js",
   "scripts": {
-    "start": "npm run build && node ./dist/server.js",
-    "dev": "npx ts-node ./src/server",
+    "start": "npm run build && node -r dotenv/config ./dist/server.js",
+    "dev": "npx ts-node -r dotenv/config ./src/server",
     "test": "jest",
     "lint": "npx eslint . --fix",
     "build": "npx tsc",
@@ -36,6 +36,7 @@
   "homepage": "https://github.com/iatenine/octo-spork#readme",
   "devDependencies": {
     "@babel/preset-env": "^7.18.6",
+    "@babel/preset-typescript": "^7.18.6",
     "@tsconfig/node16": "^1.0.3",
     "@types/express": "^4.17.13",
     "@types/jest": "^28.1.5",
@@ -56,8 +57,16 @@
     }
   },
   "dependencies": {
+    "axios": "^0.27.2",
+    "body-parser": "^1.20.0",
+    "dotenv": "^16.0.1",
     "express": "^4.18.1",
     "prettier": "^2.7.1"
   },
-  "private": false
+  "private": false,
+  "moduleFileExtensions": [
+    "js",
+    "ts",
+    "tsx"
+  ]
 }

--- a/src/data/types.ts
+++ b/src/data/types.ts
@@ -1,0 +1,15 @@
+export interface iMember {
+  first_name: string;
+  last_name: string;
+  profile_image: string;
+  chamber: "senate" | "house" | null;
+  member_id: string;
+  state?: string;
+  district?: number;
+}
+
+export interface iDistrict {
+  zip?: number;
+  state?: string;
+  district?: number;
+}

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -2,7 +2,10 @@
 import express from "express";
 import { router } from "./representatives";
 const app = express();
+import bodyParser from "body-parser";
 
+app.use(bodyParser.urlencoded({ extended: false }));
+app.use(bodyParser.json());
 app.use("/representatives", router);
 
 export { app };

--- a/src/routes/representatives.ts
+++ b/src/routes/representatives.ts
@@ -1,11 +1,16 @@
 "use strict";
 import express from "express";
+import { getRepresentatives } from "../services/representatives";
 const router = express.Router();
 
-router.get("/", (req, res) => {
-  res.json({
-    msg: "Hello, Worlddd!",
-  });
+router.post("/", async (req, res) => {
+  try {
+    const ret = await getRepresentatives(req.body);
+    res.json(ret);
+  } catch (error) {
+    console.error(error);
+    res.status(400).json(`Something went wrong`);
+  }
 });
 
 export { router };

--- a/src/services/representatives.ts
+++ b/src/services/representatives.ts
@@ -1,0 +1,46 @@
+"use strict";
+import { iMember, iDistrict } from "../data/types";
+import { getChamberMembers, getMembersByDistrict } from "../utils/apiCalls";
+import { responseToMember } from "../utils/apiHelpers";
+
+export const getRepresentatives = async (
+  body: iDistrict,
+): Promise<iMember[]> => {
+  // Check body for zip or state/dist params
+  // If none exist, return all members
+  // If only state exists return all members for that state
+  // If district exists, return uses specific members
+  if (body?.zip) {
+    return [];
+  }
+  if (body?.state) {
+    const members = await getMembersByDistrict(body.state, body?.district);
+    const res: iMember[] =
+      members?.map((elem) => responseToMember(elem, body.state)) || [];
+    if (res.length && !res[0]?.first_name)
+      throw new Error(
+        `Something went wrong. Possibly invlaid state (${body?.state}) or district (${body?.district})`,
+      );
+    return res;
+  }
+  const senators = await getChamberMembers("senate");
+  const reps = await getChamberMembers("house");
+  const senateMembers: iMember[] = senators.map(
+    (elem: {
+      first_name: string;
+      last_name: string;
+      role: string;
+      id: string;
+    }) => responseToMember(elem),
+  );
+  const repmembers: iMember[] = reps.map(
+    (elem: {
+      first_name: string;
+      last_name: string;
+      role: string;
+      id: string;
+    }) => responseToMember(elem),
+  );
+  const merge: iMember[] = [...senateMembers, ...repmembers];
+  return merge;
+};

--- a/src/utils/apiCalls.ts
+++ b/src/utils/apiCalls.ts
@@ -1,0 +1,60 @@
+import axios from "axios";
+import { json } from "body-parser";
+import { iMember } from "../data/types";
+const currentSession = 117;
+
+export const getMembersByDistrict = async (
+  inputState: string,
+  district: number | undefined,
+) => {
+  const state = inputState.toUpperCase();
+  if (state.length != 2) throw new Error(`Invalid state input: ${state}`);
+  const senateUrl = `congress/v1/members/senate/${state}/current.json`;
+  const houseUrl = `congress/v1/members/house/${state}/${district}/current.json`;
+
+  const senators = await makePropublicaCall(senateUrl);
+  const representatives = district
+    ? await makePropublicaCall(houseUrl)
+    : { results: (await getChamberMembers("house")) || [] };
+  if (senators.errors?.length)
+    throw new Error(`Error noted on call ${JSON.stringify(senators.errors)}`);
+  const filteredHouse: iMember[] = !district
+    ? representatives.results.filter(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (member: any) => member?.state === state.toUpperCase(),
+      )
+    : representatives.results;
+
+  if (!filteredHouse) throw new Error("Undefined results");
+
+  const merge = [...senators.results, ...filteredHouse];
+
+  return merge;
+};
+
+export const getChamberMembers = async (
+  chamber: "house" | "senate",
+  congress: number = currentSession,
+) => {
+  const getMembersEndpoint = `congress/v1/${congress}/${chamber}/members.json`;
+  const data = await makePropublicaCall(getMembersEndpoint);
+  return data.results[0].members;
+};
+
+export const makePropublicaCall = async (endpoint: string) => {
+  const options = {
+    method: "GET",
+    url: `https://api.propublica.org/${endpoint}`,
+    params: { "": "" },
+    headers: { "X-API-Key": process.env.PROPUBLICA_KEY || "" },
+  };
+
+  try {
+    const response = await axios.request(options);
+    return response.data;
+  } catch (error) {
+    // Need logging service to handle errors
+    //eslint-disable-next-line no-console
+    console.error(error);
+  }
+};

--- a/src/utils/apiHelpers.ts
+++ b/src/utils/apiHelpers.ts
@@ -1,0 +1,23 @@
+import { iMember } from "../data/types";
+
+export const responseToMember = (
+  memberRes: {
+    first_name: string;
+    last_name: string;
+    role: string;
+    id: string;
+    state?: string;
+  },
+  state = "",
+): iMember => {
+  const member: iMember = {
+    first_name: memberRes?.first_name,
+    last_name: memberRes?.last_name,
+    profile_image: "",
+    chamber: memberRes?.role ? "senate" : "house",
+    member_id: memberRes.id,
+    state: memberRes.state || state,
+  };
+
+  return member;
+};


### PR DESCRIPTION
User can now query for representative info based on state, state + district or no specification to view all
Invalid responses result in 400 errors handled gracefully and being logged. Future iterations should make
use of a proper logger
Closes #3